### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Hi, you have not submitted your post event report yet. Kindly use the [Post Event Template](https://github.com/oscafrica/chapter-leads-hub/blob/master/docs/post-event-template.md), submit your report and we will close this issue'
+        stale-issue-label: 'no-post-event-report'
+        days-before-issue-stale: 40
+        days-before-issue-close: -1


### PR DESCRIPTION
<!-- Love osca? Please consider supporting our collective:
👉  https://opencollective.com/osca/donate -->

#### What does this PR do?

A temporary solution to remind leads to submit their post-event report after 40 days (3 weeks minimum required before the event + < 2 weeks extra)

#### Any relevant issues this PR addresses? (optional)

N/A

#### Any background context you want to add?

The GitHub `action` adds a comment and label tag to an issue.
